### PR TITLE
Fix liked songs playback context

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -93,7 +93,7 @@ export default function LikedSongsScreen() {
                         return;
                     }
 
-                    const collectionUri = `spotify:user:${user.id}:collection`;
+                    const collectionUri = "spotify:collection:tracks";
 
                     try {
                         let wasShuffling = false;

--- a/services/spotifyPlayback.ts
+++ b/services/spotifyPlayback.ts
@@ -604,10 +604,61 @@ export const playTrackWithContext = async (
                 }
 
                 // Prepare the playback request body
-                const playbackBody: any = {
-                    context_uri: sourceContext.uri,
-                    offset: { uri: trackUri }, // Start from specific track
+                const playbackBody: Record<string, any> = {};
+
+                if (sourceContext.uri) {
+                    playbackBody.context_uri = sourceContext.uri;
+                }
+
+                const resolveLikedTrackPosition = () => {
+                    if (
+                        sourceContext?.currentIndex !== undefined &&
+                        sourceContext?.currentIndex !== null
+                    ) {
+                        return sourceContext.currentIndex;
+                    }
+
+                    if (!sourceContext?.tracks?.length) {
+                        return null;
+                    }
+
+                    const foundIndex = sourceContext.tracks.findIndex((track: any) => {
+                        if (!track) return false;
+
+                        if (typeof track === "string") {
+                            return track === trackUri;
+                        }
+
+                        if (track?.uri) {
+                            return track.uri === trackUri;
+                        }
+
+                        if (track?.track?.uri) {
+                            return track.track.uri === trackUri;
+                        }
+
+                        return false;
+                    });
+
+                    return foundIndex >= 0 ? foundIndex : null;
                 };
+
+                if (sourceContext?.type === "liked") {
+                    const likedPosition = resolveLikedTrackPosition();
+
+                    if (likedPosition !== null) {
+                        playbackBody.offset = { position: likedPosition };
+                        log("Playback: Using liked songs position", likedPosition);
+                    } else {
+                        playbackBody.offset = { uri: trackUri };
+                        log(
+                            "Playback: Falling back to URI offset for liked songs",
+                            trackUri
+                        );
+                    }
+                } else if (trackUri) {
+                    playbackBody.offset = { uri: trackUri }; // Start from specific track
+                }
 
                 // Web API to set context + track offset
                 const playUrl = deviceId


### PR DESCRIPTION
## Summary
- use the global Liked Songs collection URI when starting playback from the Liked tab
- compute an index-based offset for liked tracks when calling the Web API so playback reliably starts at the chosen song

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b0efbd6c8323b556d08f3b7be929